### PR TITLE
Quote double-quotes and include dummy commands

### DIFF
--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -348,8 +348,14 @@ int main(int argc, char *argv[]) {
 
     int wstatus;
 
-    while (auto pid = wait(&wstatus)) {
+    while (true) {
+      const auto pid = wait(&wstatus);
+
       if (pid == -1) {
+        if (errno == ECHILD) {
+          break;
+        }
+
         perror("cannot wait()");
         return -1;
       }

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -8,10 +8,8 @@
 
 #include <linux/limits.h>
 
-#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <iterator>
 #include <memory>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
Fixes for invalid JSON generated in the two following cases:
1. Empty sections if no source files are found within the command.  E.g.
```
[,,,,,,,,,,
  {
```
```
},,,
```
```
}
{
```
I decided to still include a "dummy" section with null file rather than completely ignoring such commands just to have a record of such a thing happening.  Tools like clangd do not care.
```
  {
    "directory": "/home/user",
    "command": "gcc -v ",
    "file": null
  },
```

2. Unquoted double-quotes in arguments. E.g.:
```
     "-DPREFIX="/usr"",
```