### PR TITLE
Do not report error when no child process can be wait()-ed

### DIFF
--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -319,8 +319,14 @@ int main(int argc, char *argv[]) {
 
     int wstatus;
 
-    while (auto pid = wait(&wstatus)) {
+    while (true) {
+      const auto pid = wait(&wstatus);
+
       if (pid == -1) {
+        if (errno == ECHILD) {
+          break;
+        }
+
         perror("cannot wait()");
         return -1;
       }


### PR DESCRIPTION
Do not treat wait() returning -1 and ECHILD as an error.