### PR TITLE
JSON-escape strings

### DIFF
--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -30,12 +30,10 @@ using std::vector;
 using std::literals::string_literals::operator""s;
 
 string json_escape(const string &str) {
-  static const char hex[] = "0123456789abcdef";
-  char u[] = "u0000";
   std::string s;
 
   for (auto c : str) {
-    if (static_cast<unsigned char>(c) < 0x20) {
+    if (c >= 0 && c < 0x20) {
       s.push_back('\\');
 
       switch (c) {
@@ -55,6 +53,8 @@ string json_escape(const string &str) {
         c = 'r';
         break;
       default:
+        static const char hex[] = "0123456789abcdef";
+        char u[] = "u0000";
         u[3] = hex[c >> 4];
         u[4] = hex[c & 0xf];
         s.append(u);

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -246,7 +246,7 @@ void CompilationDatabase::add(const string &directory,
       *this << "\n"
                // clang-format off
                "      \"" << json_escape(arg) << '\"';
-               // clang-format on
+      // clang-format on
     }
 
     *this << "\n"

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -29,6 +29,46 @@ using std::unordered_set;
 using std::vector;
 using std::literals::string_literals::operator""s;
 
+string json_escape(const string &str) {
+  static const char hex[] = "0123456789abcdef";
+  std::string s;
+
+  for (const auto c : str) {
+    if (c == '\\' || c == '"') {
+      s.push_back('\\');
+      s.push_back(c);
+      continue;
+    }
+    if (c < 0x20) {
+      switch (c) {
+      case '\b':
+        s.append("\\b");
+        break;
+      case '\t':
+        s.append("\\t");
+        break;
+      case '\n':
+        s.append("\\n");
+        break;
+      case '\f':
+        s.append("\\f");
+        break;
+      case '\r':
+        s.append("\\r");
+        break;
+      default:
+        s.append("\\u00");
+        s.push_back(hex[c >> 4]);
+        s.push_back(hex[c & 0xf]);
+      }
+    } else {
+      s.push_back(c);
+    }
+  }
+
+  return s;
+}
+
 class Pipe {
 public:
   Pipe();
@@ -190,7 +230,7 @@ void CompilationDatabase::add(const string &directory,
     *this << "\n"
              "  {\n"
              // clang-format off
-             "    \"directory\": \"" << directory << "\",\n"
+             "    \"directory\": \"" << json_escape(directory) << "\",\n"
              // clang-format on
              "    \"arguments\": [";
 
@@ -205,14 +245,14 @@ void CompilationDatabase::add(const string &directory,
 
       *this << "\n"
                // clang-format off
-               "      \"" << arg << '\"';
-      // clang-format on
+               "      \"" << json_escape(arg) << '\"';
+               // clang-format on
     }
 
     *this << "\n"
              "    ],\n"
              // clang-format off
-             "    \"file\": \"" << file << "\"\n"
+             "    \"file\": \"" << json_escape(file) << "\"\n"
              // clang-format on
              "  }";
   }

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -31,39 +31,40 @@ using std::literals::string_literals::operator""s;
 
 string json_escape(const string &str) {
   static const char hex[] = "0123456789abcdef";
+  char u[] = "u0000";
   std::string s;
 
-  for (const auto c : str) {
-    if (c == '\\' || c == '"') {
+  for (auto c : str) {
+    if (static_cast<unsigned char>(c) < 0x20) {
       s.push_back('\\');
-      s.push_back(c);
-      continue;
-    }
-    if (c < 0x20) {
+
       switch (c) {
       case '\b':
-        s.append("\\b");
+        c = 'b';
         break;
       case '\t':
-        s.append("\\t");
+        c = 't';
         break;
       case '\n':
-        s.append("\\n");
+        c = 'n';
         break;
       case '\f':
-        s.append("\\f");
+        c = 'f';
         break;
       case '\r':
-        s.append("\\r");
+        c = 'r';
         break;
       default:
-        s.append("\\u00");
-        s.push_back(hex[c >> 4]);
-        s.push_back(hex[c & 0xf]);
+        u[3] = hex[c >> 4];
+        u[4] = hex[c & 0xf];
+        s.append(u);
+        continue;
       }
-    } else {
-      s.push_back(c);
+    } else if (c == '\\' || c == '"') {
+      s.push_back('\\');
     }
+
+    s.push_back(c);
   }
 
   return s;


### PR DESCRIPTION
Add JSON-escaping for string values (e.g. arguments and filenames) in the output.