### PR TITLE
Support for incremental update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-CXXFLAGS=-std=c++17
+CXXFLAGS := -std=c++17 $(CXXFLAGS) $(pkg-config --cflags nlohmann_json)
+OBJECTS  := $(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
 
-OBJECTS:=$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
-
-basset: $(OBJECTS)
-	$(CXX) $(OBJECTS) $(LDFLAGS) $(LIBS) -o $@
+.PHONY: all clean
 
 all: basset
 
 clean:
-	rm -rf $(OBJECTS) basset
+	$(RM) $(OBJECTS) basset
+
+basset: $(OBJECTS)
+	$(CXX) $(OBJECTS) $(LDFLAGS) $(LIBS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=--std=c++17
+CXXFLAGS=-std=c++17
 
 OBJECTS:=$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CXXFLAGS=--std=c++14
+
 OBJECTS:=$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
 
 basset: $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=--std=c++14
+CXXFLAGS=--std=c++17
 
 OBJECTS:=$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Your feedback (both positive and negative) is highly appreciated!
 
 ## prerequisites
 
-You will need `make` and C++ compiler.
+You will need `make`, C++ compiler supporting C++14 and [nlohmann/json] library.
 
 ## compile
 
@@ -61,6 +61,7 @@ Extra options can precede `--` if needed.
 [clang]: https://clang.llvm.org
 [compile-db-gen]: https://github.com/sunlin7/compile-db-gen
 [compiledb]: https://github.com/nickdiego/compiledb
+[nlohmann/json]: https://github.com/nlohmann/json
 [procfs]: https://en.wikipedia.org/wiki/Procfs
 [ptrace]: https://en.wikipedia.org/wiki/Ptrace
 [strace]: https://strace.io

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Your feedback (both positive and negative) is highly appreciated!
 
 ## prerequisites
 
-You will need `make`, C++ compiler supporting C++14 and [nlohmann/json] library.
+You will need `make`, C++ compiler supporting C++17 and [nlohmann/json] library.
 
 ## compile
 

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -1,7 +1,5 @@
 #include <fcntl.h>
 #include <regex.h>
-#include <signal.h>
-#include <stdio.h>
 #include <unistd.h>
 
 #include <sys/ptrace.h>
@@ -9,6 +7,8 @@
 
 #include <linux/limits.h>
 
+#include <csignal>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <memory>

--- a/src/basset.cpp
+++ b/src/basset.cpp
@@ -114,7 +114,7 @@ public:
   [[nodiscard]] bool match(const string &text) const;
 
 private:
-  [[noreturn]] void report(ssize_t errcode) const;
+  [[noreturn]] void report(int errcode) const;
   regex_t preg;
 };
 
@@ -141,7 +141,7 @@ bool Regex::match(const string &text) const {
   }
 }
 
-void Regex::report(ssize_t errcode) const {
+void Regex::report(int errcode) const {
   auto size = regerror(errcode, &preg, nullptr, 0);
   auto errbuf = make_unique<char>(size);
   regerror(errcode, &preg, errbuf.get(), size);


### PR DESCRIPTION
Adds support for incremental update of the compile database if it already exists.   Basically, if a new compilation entry is detected, it overrides the entry referring to the same source file if it already exists, otherwise it's simply added.   The source file is uniquely identified by "canonized" path constructed from `directory` and `file` values.

An external library - nlohmann/json (https://github.com/nlohmann/json) - is used as JSON handling is significantly more complex now.