### PR TITLE
Move from Gitpod to GitHub Codespaces

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,0 @@
-vscode:
-  extensions:
-  - llvm-vs-code-extensions.vscode-clangd

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# basset [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/i-ky/basset)
+# basset [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/i-ky/basset)
 
 A tool that generates a
 [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html)


### PR DESCRIPTION
Gitpod is morphing into Ona and seems to become a paid service.

Move to GitHub Codespaces as a free option.